### PR TITLE
update docstrings

### DIFF
--- a/src/poliastro/twobody/orbit.py
+++ b/src/poliastro/twobody/orbit.py
@@ -107,12 +107,12 @@ class Orbit(object):
 
     @property
     def a(self):
-        """Semilatus rectum. """
+        """Semimajor axis. """
         return self.p / (1 - self.ecc ** 2)
 
     @property
     def p(self):
-        """Semimajor axis. """
+        """Semilatus rectum. """        
         return self._state.to_classical().p
 
     @property


### PR DESCRIPTION
interchanged the positions of the below shown doc strings as they are interchaged

```
@property 
 def a(self): 
     """Semilatus rectum. """ 
     return self.p / (1 - self.ecc ** 2) 
  
 @property 
 def p(self): 
     """Semimajor axis. """ 
     return self._state.to_classical().p
```